### PR TITLE
Use correct rustls feature flag for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sync = ["reqwest/blocking"]
 # Need futures for Async
 async = []
 
-rustls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 url = "2.2.2"

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use serde::{ser::Error as SerializeError, Serialize, Serializer};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 /// Indicates the severity of the impact to the affected system.
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Info,
@@ -98,7 +98,7 @@ pub struct Change<T: Serialize> {
     pub links: Option<Links>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct AlertTriggerPayload<T: Serialize> {
     /// The perceived severity of the status the event is describing with respect to the affected system.
     /// This can be critical, error, warning or info.
@@ -165,7 +165,7 @@ pub struct AlertAcknowledge {
     pub dedup_key: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct AlertResolve {
     pub dedup_key: String,
 }


### PR DESCRIPTION
The feature flag for enabling rustls support in reqwest is
`reqwest/rustls-tls`, so set that value correctly in Cargo.toml.